### PR TITLE
Moved logic and tests for case insensitive usernames.

### DIFF
--- a/argonblake.go
+++ b/argonblake.go
@@ -2,11 +2,9 @@ package lckbx
 
 import (
 	"fmt"
-	"strings"
 
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/text/unicode/norm"
 )
 
 // argonBlakeDerive implements the deriver interface using Argon2 and Blake2b.
@@ -21,10 +19,6 @@ type argonBlakeDerive struct {
 // DeriveBaseKey takes a username and passphrase and returns a BaseKey.
 func (a argonBlakeDerive) DeriveBaseKey(username, passphrase string) (BaseKey, error) {
 	var bk BaseKey
-
-	// Normalize our username and password
-	username = strings.ToLower(norm.NFKD.String(username))
-	passphrase = norm.NFKD.String(passphrase)
 
 	// Verify password length
 	if len(passphrase) < minPassphraseLength {

--- a/argonblake_test.go
+++ b/argonblake_test.go
@@ -2,7 +2,6 @@ package lckbx
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 

--- a/argonblake_test.go
+++ b/argonblake_test.go
@@ -43,15 +43,6 @@ func testArgonBlakeDeriveBaseKey(t *testing.T) {
 	if bk.String() != argonBlakeBaseKey {
 		t.Fatal("Expected", argonBlakeBaseKey, ", received", bk.String())
 	}
-
-	ubk, err := deriver.DeriveBaseKey(strings.ToUpper(deriveUsername), deriveGoodPassword)
-	if err != nil {
-		t.Fatal("Expected no error, received", err)
-	}
-
-	if ubk.String() != argonBlakeBaseKey {
-		t.Fatal("Expected", argonBlakeBaseKey, ", received", ubk.String())
-	}
 }
 
 func testArgonBlakeDeriveAuthKey(t *testing.T) {

--- a/lockedbox.go
+++ b/lockedbox.go
@@ -2,6 +2,9 @@ package lckbx
 
 import (
 	"fmt"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 type LockedBox struct {
@@ -17,7 +20,12 @@ type LockedBox struct {
 //  4. Store the Metadata encrypted with the Metadata key derived from the
 //     keyset.
 func (l *LockedBox) Register(username, password string) error {
-	// 1. Create a new User, Keyset, and Metadata.
+	// 1.  Create a new User, Keyset, and Metadata.
+	// 1.a Normalize the username and password.
+	username = strings.ToLower(norm.NFKD.String(username))
+	password = norm.NFKD.String(password)
+
+	// 1.b Create the user, keyset, and metadata objects.
 	user := NewUser(username)
 	keyset := NewKeyset(user.KeysetId)
 	metadata := NewMetadata(user.MetadataId)
@@ -90,6 +98,10 @@ func (l *LockedBox) Login(username, password string) (UnlockedBox, error) {
 	var ub UnlockedBox
 
 	// 1.  Get the UserId from the database using the given username.
+	// Normalize our username and password
+	username = strings.ToLower(norm.NFKD.String(username))
+	password = norm.NFKD.String(password)
+
 	userId := l.store.GetUserId(username)
 
 	// 2.  Derive an AuthToken, AuthKey, and CryptKey for the user.
@@ -165,6 +177,11 @@ func (l *LockedBox) Login(username, password string) (UnlockedBox, error) {
 //  5. Save the Metadata encrypted with the new Metadata key in the keyset.
 func (l *LockedBox) ChangePassword(username, oldPassword, newPassword string) error {
 	// 1.  Login to get an UnlockedBox
+	// Normalize our username and password
+	username = strings.ToLower(norm.NFKD.String(username))
+	oldPassword = norm.NFKD.String(oldPassword)
+	newPassword = norm.NFKD.String(newPassword)
+
 	ub, err := l.Login(username, oldPassword)
 	if err != nil {
 		return fmt.Errorf("could not LockedBox.ChangePassword: %v", err)

--- a/lockedbox_test.go
+++ b/lockedbox_test.go
@@ -2,6 +2,7 @@ package lckbx
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -48,6 +49,12 @@ func testRegister(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error for existing user, received nil")
 	}
+
+	// Register the same user with a different case.
+	err = lb.Register(strings.ToUpper(lockedBoxUser), lockedBoxGoodPassword)
+	if err != nil {
+		t.Fatalf("Expected error for existing uppercase user, received nil")
+	}
 }
 
 func testLogin(t *testing.T) {
@@ -87,6 +94,20 @@ func testLogin(t *testing.T) {
 
 	if unlocked.user.MetadataId != unlocked.metadata.MetadataId {
 		t.Fatal("Expected", unlocked.metadata.MetadataId, ", received", unlocked.user.MetadataId)
+	}
+
+	// Attempt to login with an uppercase username.
+	upper, err := lb.Login(strings.ToUpper(lockedBoxUser), lockedBoxGoodPassword)
+	if upper.user.UserName != lockedBoxUser {
+		t.Fatal("Expected", lockedBoxUser, ", received", upper.user.UserName)
+	}
+
+	if upper.user.KeysetId != upper.keyset.KeysetId {
+		t.Fatal("Expected", upper.keyset.KeysetId, ", received", upper.user.KeysetId)
+	}
+
+	if upper.user.MetadataId != upper.metadata.MetadataId {
+		t.Fatal("Expected", upper.metadata.MetadataId, ", received", upper.user.MetadataId)
 	}
 }
 
@@ -140,7 +161,7 @@ func testChangePassword(t *testing.T) {
 	}
 
 	if len(unlocked2.keyset.Keys) != 2 {
-		t.Fatalf("Expected two key in new Keyset found %d", len(unlocked2.keyset.Keys))
+		t.Fatalf("Expected two keys in new Keyset, found %d", len(unlocked2.keyset.Keys))
 	}
 
 	// The latest key in each keyset should be different since changing the
@@ -155,5 +176,46 @@ func testChangePassword(t *testing.T) {
 	// Metadatas should be equal
 	if !unlocked1.metadata.Equal(unlocked2.metadata) {
 		t.Fatalf("Expected metadatas to be equal, received\n%v\n%v", unlocked1.metadata, unlocked2.metadata)
+	}
+
+	// Change the password for uppercase user.
+	err = lb.ChangePassword(strings.ToUpper(lockedBoxUser), lockedBoxBadPassword, lockedBoxGoodPassword)
+	if err != nil {
+		t.Fatalf("Expected no error, received %v", err)
+	}
+
+	// Login with the updated password.
+	upper, err := lb.Login(lockedBoxUser, lockedBoxGoodPassword)
+	if err != nil {
+		t.Fatalf("Expected no error, received %v", err)
+	}
+
+	// Users should be equal
+	if !unlocked1.user.Equal(upper.user) {
+		t.Fatalf("Expected users to be equal, received\n%v\n%v", unlocked1.user, upper.user)
+	}
+
+	// Keysets will not be equal because a password change adds a new key to
+	// the map, which updates the latest value. Check what we can to ensure
+	// the Keyset is what we expect.
+	if unlocked1.keyset.KeysetId != upper.keyset.KeysetId {
+		t.Fatalf("Expected keyset Ids to be equal, received %s %s", unlocked1.keyset.KeysetId, upper.keyset.KeysetId)
+	}
+
+	if len(upper.keyset.Keys) != 3 {
+		t.Fatalf("Expected three keys in new Keyset, found %d", len(upper.keyset.Keys))
+	}
+
+	// The latest key in each keyset should be different since changing the
+	// password added a new key.
+	uksi, _ := upper.keyset.GetLatestKey()
+
+	if ksi1.Equal(uksi) {
+		t.Fatalf("Expected Keyset items to be unequal, received \n%v\n%v", ksi1, uksi)
+	}
+
+	// Metadatas should be equal
+	if !unlocked1.metadata.Equal(upper.metadata) {
+		t.Fatalf("Expected metadatas to be equal, received\n%v\n%v", unlocked1.metadata, upper.metadata)
 	}
 }

--- a/lockedbox_test.go
+++ b/lockedbox_test.go
@@ -52,7 +52,7 @@ func testRegister(t *testing.T) {
 
 	// Register the same user with a different case.
 	err = lb.Register(strings.ToUpper(lockedBoxUser), lockedBoxGoodPassword)
-	if err != nil {
+	if err == nil {
 		t.Fatalf("Expected error for existing uppercase user, received nil")
 	}
 }


### PR DESCRIPTION
I originally added the username and password normalization to the Deriver but it needs to be at the LockedBox level. Moved logic and tests from Deriver to LockedBox.